### PR TITLE
Change the Orange Belgium Network name, and fix Mobile Viking APN an…

### DIFF
--- a/mobile-broadband-provider-info/serviceproviders.xml
+++ b/mobile-broadband-provider-info/serviceproviders.xml
@@ -1203,7 +1203,7 @@ conceived.
 			<apn value="mworld.be">
 				<plan type="postpaid"/>
 				<usage type="internet"/>
-				<name>Internet mobile</name>
+				<name>Orange Mobile Internet</name>
 			</apn>
 		</gsm>
 	</provider>
@@ -1253,26 +1253,19 @@ conceived.
 				<mmsc>http://mmsc.base.be</mmsc>
 				<mmsproxy>217.72.235.1:8080</mmsproxy>
 			</apn>
-			<apn value="mms.be">
-				<usage type="mms"/>
-				<name>Mobile Vikings MMS</name>
-				<username>mms</username>
-				<password>mms</password>
-				<mmsc>http://mmsc.be</mmsc>
-				<mmsproxy>217.72.235.1:8080</mmsproxy>
-			</apn>
 		</gsm>
 	</provider>
 	<provider>
 		<name>Mobile Vikings</name>
 		<gsm>
-			<network-id mcc="206" mnc="20"/>
+			<network-id mcc="206" mnc="01"/>
 			<voicemail>1933</voicemail>
-			<apn value="web.be">
+			<apn value="internet.proximus.be">
 				<plan type="prepaid"/>
 				<usage type="internet"/>
 				<username>web</username>
 				<password>web</password>
+				<name>Mobile Vikings Internet</name>
 			</apn>
 		</gsm>
 	</provider>


### PR DESCRIPTION
…d MNC to the correct one

The Mobile Viking MNC would not be correct also not the APN name as it use the same APN as Proximus, i have correct this into the code. See the info on the website of Mobile Vikings if you like to check the correct APN and MNC code.

Also Mobile Vikings dont support MMS anymore, i have remove this also.

https://support.mobilevikings.be/hc/nl/articles/202836041-Ik-heb-geen-mobiel-internet-Wat-moet-ik-doen